### PR TITLE
Add dependabot for helm charts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "helm"
+    directory: "/charts"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add Dependabot configuration to keep Helm chart dependencies up to date

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adb66213483288bd772bee35bd5ad